### PR TITLE
Add workflows and sync configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,2 @@
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+_extends: .github

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -13,6 +13,8 @@ group:
       - source: workflows/proto/
         dest: .github/workflows/
         deleteOrphaned: true
+        exclude: |
+          basic-linters.yml
     repos: |-
       valitydev/damsel
 

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,25 @@
+group:
+  - id: default
+    files:
+      - source: workflows/base/basic-linters.yml
+        dest: .github/workflows/basic-linters.yml
+      - source: LICENSE
+        dest: LICENSE
+    repos: |-
+      valitydev/damsel
+
+  - id: proto
+    files:
+      - source: workflows/proto/
+        dest: .github/workflows/
+        deleteOrphaned: true
+    repos: |-
+      valitydev/damsel
+
+  - id: java
+    files:
+      - source: codeowners/java
+        dest: CODEOWNERS
+        replace: false
+    repos: |-
+      valitydev/newway

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -7,6 +7,7 @@ group:
         dest: LICENSE
     repos: |-
       valitydev/damsel
+      valitydev/newway
 
   - id: proto
     files:

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -5,6 +5,8 @@ group:
         dest: .github/workflows/basic-linters.yml
       - source: LICENSE
         dest: LICENSE
+      - source: .github/settings.yml
+        replace: false
     repos: |-
       valitydev/damsel
       valitydev/newway

--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -1,0 +1,20 @@
+name: Sync files
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code
+        uses: actions/checkout@v2
+
+      - name: 🔄 Sync repo files
+        uses: valitydev/repo-file-sync-action@v1
+        with:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+          BRANCH_PREFIX: update/

--- a/.github/workflows/sync-repo-list.yml
+++ b/.github/workflows/sync-repo-list.yml
@@ -1,0 +1,77 @@
+name: Sync repo list in sync.yml file
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  schedule:
+    - cron: 0 * * * *
+
+env:
+  repo_limit: 1000
+
+jobs:
+  workflows-sync:
+    name: Sync repositories for ${{ matrix.group }} group
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - group: default
+
+          - group: proto
+            languages: |
+              thrift
+
+          - group: java
+            languages: |
+              java
+              kotlin
+    steps:
+      - name: ⤵️ Check out code
+        uses: actions/checkout@v2
+
+      - name: 📤 Get a list of repositories for ${{ matrix.group }} group
+        id: repo-list
+        run: |
+          LANGUAGE_ARGS=""
+          if [[ "${{ matrix.group }}" != "default" ]]; then
+              LANGUAGE_ARGS="-l ${{ matrix.group }}"
+          fi
+          REPOSITORIES=$(gh repo list \
+              $OWNER \
+              --public \
+              --source \
+              --no-archived \
+              -L $repo_limit \
+              $LANGUAGE_ARGS \
+              --json name,owner \
+              -q '.|=sort_by(.name)| .[] | [.owner.login, .name] | join("/")')
+          REPOSITORIES="${REPOSITORIES//'%'/'%25'}"
+          REPOSITORIES="${REPOSITORIES//$'\n'/'%0A'}"
+          REPOSITORIES="${REPOSITORIES//$'\r'/'%0D'}"
+          echo "::set-output name=repositories::$REPOSITORIES"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+
+      - name: 🔄 Update sync.yml file for ${{ matrix.group }} group
+        uses: fjogeleit/yaml-update-action@master
+        with:
+          valueFile: ".github/sync.yml"
+          propertyPath: >-
+            $.group[?(@.id == "${{ matrix.group }}")].repos
+          value: ${{ steps.repo-list.outputs.repositories }}
+          updateFile: true
+          commitChange: false
+
+      - name: 📤 Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: master
+          branch: updates/${{ matrix.group }}
+          title: "Update repo list for ${{ matrix.group }} group"
+          commit-message: "Update repo list for ${{ matrix.group }} group"
+          add-paths: |
+            .github/sync.yml

--- a/.github/workflows/sync-repo-list.yml
+++ b/.github/workflows/sync-repo-list.yml
@@ -39,7 +39,7 @@ jobs:
         id: repo-list
         run: |
           REPOSITORIES=""
-          for language in "${{ matrix.languages }}"; do
+          for language in ${{ matrix.languages }}; do
               LANGUAGE_ARGS=""
               if [[ $language != "all" ]]; then
                   LANGUAGE_ARGS="-l $language"

--- a/.github/workflows/sync-repo-list.yml
+++ b/.github/workflows/sync-repo-list.yml
@@ -1,7 +1,6 @@
 name: Sync repo list in sync.yml file
 
 on:
-  pull_request:
   push:
     branches:
       - master
@@ -76,7 +75,7 @@ jobs:
       - name: 📤 Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          base: ft/add_workflows_and_sync_configuration
+          base: master
           branch: updates/${{ matrix.group }}
           title: "Update repo list for ${{ matrix.group }} group"
           commit-message: "Update repo list for ${{ matrix.group }} group"

--- a/.github/workflows/sync-repo-list.yml
+++ b/.github/workflows/sync-repo-list.yml
@@ -20,15 +20,15 @@ jobs:
       matrix:
         include:
           - group: default
-            languages: >
+            languages: >-
               all
 
           - group: proto
-            languages: >
+            languages: >-
               thrift
 
           - group: java
-            languages: >
+            languages: >-
               java
               kotlin
     steps:

--- a/.github/workflows/sync-repo-list.yml
+++ b/.github/workflows/sync-repo-list.yml
@@ -76,7 +76,7 @@ jobs:
       - name: 📤 Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          base: master
+          base: ft/add_workflows_and_sync_configuration
           branch: updates/${{ matrix.group }}
           title: "Update repo list for ${{ matrix.group }} group"
           commit-message: "Update repo list for ${{ matrix.group }} group"

--- a/.github/workflows/sync-repo-list.yml
+++ b/.github/workflows/sync-repo-list.yml
@@ -20,15 +20,15 @@ jobs:
       matrix:
         include:
           - group: default
-            languages: |
+            languages: >
               all
 
           - group: proto
-            languages: |
+            languages: >
               thrift
 
           - group: java
-            languages: |
+            languages: >
               java
               kotlin
     steps:

--- a/.github/workflows/sync-repo-list.yml
+++ b/.github/workflows/sync-repo-list.yml
@@ -1,6 +1,7 @@
 name: Sync repo list in sync.yml file
 
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -19,6 +20,8 @@ jobs:
       matrix:
         include:
           - group: default
+            languages: |
+              all
 
           - group: proto
             languages: |
@@ -35,19 +38,22 @@ jobs:
       - name: 📤 Get a list of repositories for ${{ matrix.group }} group
         id: repo-list
         run: |
-          LANGUAGE_ARGS=""
-          if [[ "${{ matrix.group }}" != "default" ]]; then
-              LANGUAGE_ARGS="-l ${{ matrix.group }}"
-          fi
-          REPOSITORIES=$(gh repo list \
+          for language in ${{ matrix.languages }}; do
+              LANGUAGE_ARGS=""
+              if [[ $language != "all" ]]; then
+                  LANGUAGE_ARGS="-l $language"
+              fi
+              REPOSITORIES+=$(gh repo list \
               $OWNER \
               --public \
-              --source \
               --no-archived \
               -L $repo_limit \
               $LANGUAGE_ARGS \
               --json name,owner \
               -q '.|=sort_by(.name)| .[] | [.owner.login, .name] | join("/")')
+              REPOSITORIES+=" "
+          done
+          REPOSITORIES=$(echo $REPOSITORIES | sort | uniq | tr " " "\n")
           REPOSITORIES="${REPOSITORIES//'%'/'%25'}"
           REPOSITORIES="${REPOSITORIES//$'\n'/'%0A'}"
           REPOSITORIES="${REPOSITORIES//$'\r'/'%0D'}"

--- a/.github/workflows/sync-repo-list.yml
+++ b/.github/workflows/sync-repo-list.yml
@@ -38,14 +38,15 @@ jobs:
       - name: 📤 Get a list of repositories for ${{ matrix.group }} group
         id: repo-list
         run: |
-          for language in ${{ matrix.languages }}; do
+          REPOSITORIES=""
+          for language in "${{ matrix.languages }}"; do
               LANGUAGE_ARGS=""
               if [[ $language != "all" ]]; then
                   LANGUAGE_ARGS="-l $language"
               fi
               REPOSITORIES+=$(gh repo list \
               $OWNER \
-              --public \
+              --source \
               --no-archived \
               -L $repo_limit \
               $LANGUAGE_ARGS \

--- a/codeowners/java
+++ b/codeowners/java
@@ -1,0 +1,1 @@
+*       @valitydev/java

--- a/workflows/base/auto-tag.yml
+++ b/workflows/base/auto-tag.yml
@@ -1,0 +1,11 @@
+name: Vality auto-tags
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  tag-action:
+    uses: valitydev/base-workflows/.github/workflows/auto-tag.yml@v1

--- a/workflows/base/auto-tag.yml
+++ b/workflows/base/auto-tag.yml
@@ -3,8 +3,8 @@ name: Vality auto-tags
 on:
   push:
     branches:
-      - master
-      - main
+      - "master"
+      - "main"
 
 jobs:
   tag-action:

--- a/workflows/base/basic-linters.yml
+++ b/workflows/base/basic-linters.yml
@@ -1,0 +1,10 @@
+name: Vality basic linters
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  lint:
+    uses: valitydev/base-workflows/.github/workflows/basic-linters.yml@v1

--- a/workflows/proto/erlang-pr.yml
+++ b/workflows/proto/erlang-pr.yml
@@ -1,0 +1,34 @@
+name: Erlang build
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    name: Build and verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: valitydev/action-setup-thrift@v1
+
+      - uses: erlef/setup-beam@v1
+        id: beam
+        with:
+          otp-version: "24"
+          rebar3-version: "3.18"
+
+      - name: Restore PLT cache
+        uses: actions/cache@v2
+        id: plt-cache
+        with:
+          key: |
+            ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-plt
+          path: |
+            _build/default/rebar3_*_plt
+
+      - run: rebar3 compile
+      - run: rebar3 xref
+      - run: rebar3 dialyzer

--- a/workflows/proto/java-deploy.yml
+++ b/workflows/proto/java-deploy.yml
@@ -1,0 +1,17 @@
+name: Java deploy
+
+on:
+  push:
+    branches:
+      - "master"
+      - "main"
+
+jobs:
+  deploy:
+    uses: valitydev/java-workflow/.github/workflows/maven-thrift-deploy.yml@v1
+    secrets:
+      server-username: ${{ secrets.OSSRH_USERNAME }}
+      server-password: ${{ secrets.OSSRH_TOKEN }}
+      deploy-secret-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+      deploy-secret-key-password: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+      mm-webhook-url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}

--- a/workflows/proto/java-pr.yml
+++ b/workflows/proto/java-pr.yml
@@ -1,0 +1,10 @@
+name: Java build
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    uses: valitydev/java-workflow/.github/workflows/maven-service-build.yml@v1

--- a/workflows/proto/java-pr.yml
+++ b/workflows/proto/java-pr.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   build:
-    uses: valitydev/java-workflow/.github/workflows/maven-service-build.yml@v1
+    uses: valitydev/java-workflow/.github/workflows/maven-thrift-build.yml@v1


### PR DESCRIPTION
Данный репозиторий хранит конфигурационные файлы, шаблоны на workflow и workflow синхронизации этих файлов по репозиториям. Файлы поделены на группы, описание синхронизации хранится в файле `.github/sync.yml`.

Для примера сейчас описаны 3 группы: default, proto, java. В default попадают общие файлы на все типы репозиториев (LICENSE, .github/settings.yml и тд), в proto workflow файлы, идентичные от репозитория к репозиторию. В java файл `CODEOWNERS`.

```yml
group:
  - id: default
    files:
         # базовые workflow
      - source: workflows/base/basic-linters.yml
        dest: .github/workflows/basic-linters.yml
      - source: LICENSE
        dest: LICENSE
        # Файл для синхронизации настроек репозиториев: https://probot.github.io/apps/settings/
        # По умолчанию конфигурация наследуется из этого файла https://github.com/valitydev/.github/blob/master/.github/settings.yml
        # Отдельные конфигурации можно переопределять, поэтому тут стоит `replace: false`,
        # чтобы не перезатирать переопределение
      - source: .github/settings.yml
        replace: false
    repos: |-
      valitydev/damsel
      valitydev/newway
  - id: proto
    files:
         # базовые workflow для репозиториев с трифт
         # на данный момент полностью перезатирают текущие
         # в рамках синхронизации (кроме базовых)
      - source: workflows/proto/
        dest: .github/workflows/
        deleteOrphaned: true
        exclude: |
          basic-linters.yml
    repos: |-
      valitydev/damsel
  - id: java
    files:
        # пример с джавовыми репозиториями
        # Ранее заданный CODEOWNERS также не перезатирается
      - source: codeowners/java
        dest: CODEOWNERS
        replace: false
    repos: |-
      valitydev/newway
```

Пример выполнения можно увидеть в pr c [newway](https://github.com/valitydev/newway/pull/30) и [damsel](https://github.com/valitydev/damsel/pull/27).

Сам файл `sync.yml` автоматически обновляется с созданием pr на изменения. Синхронизацию производит workflow [sync-repo-list.yml](https://github.com/valitydev/configurations/pull/2/files#diff-47a5d460cd506d052abcdebc082b32a1f3d95277fb76f39737f2134992254aa5). В нем самом идет указание какую группу в рамках каких языков заполнить:

```yml
- group: default
    languages: >-
      all
- group: proto
   languages: >-
     thrift
- group: java
   languages: >-
     java
     kotlin
```
Пример автосозданных pr можно увидеть [здесь](https://github.com/valitydev/configurations/pulls).

В рамках PR нужно досинхронизировать workflow для proto группы, тут нужна помощь в финальных версиях сборок.
